### PR TITLE
Fix invalid country json on registration form

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/form/register.phtml
@@ -335,9 +335,9 @@ script;
                 "regionInputId": "#region",
                 "postcodeId": "#zip",
                 "form": "#form-validate",
-                "regionJson": {$regionJson},
-                "defaultRegion": "{$regionId}",
-                "countriesWithOptionalZip": {$countriesWithOptionalZip}
+                "regionJson": <?= $regionJson ?>,
+                "defaultRegion": "<?= $regionId ?>",
+                "countriesWithOptionalZip": <?= $countriesWithOptionalZip ?>
             }
         }
     }


### PR DESCRIPTION
PHP variables weren't being evaluated properly inside the javascript block

### Description (*)
The PHP variables that were being created were going unused and throwing an error for `apply.js getNodeData()`

### Manual testing scenarios (*)
1. Visit /customer/account/create/
2. View js error console
3. Look for the "getNodeData expecting }" error

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds are green)
